### PR TITLE
Add admin button to navbar

### DIFF
--- a/.changeset/friendly-hairs-pump.md
+++ b/.changeset/friendly-hairs-pump.md
@@ -1,0 +1,5 @@
+---
+"@edgelabs/app": minor
+---
+
+Add Admin page to navbar

--- a/apps/app/src/components/Navbar/Navbar.tsx
+++ b/apps/app/src/components/Navbar/Navbar.tsx
@@ -100,7 +100,7 @@ export const Navbar: FC = () => {
                         </NavLink>
                     ))}
 
-                    {!app_id && userData?.admin === true && (
+                    {!app_id && userData?.admin && (
                         <NavLink
                             to={'/admin'}
                             className={({ isActive }) =>

--- a/apps/app/src/components/Navbar/Navbar.tsx
+++ b/apps/app/src/components/Navbar/Navbar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-identical-functions */
 import { cx } from '@utils/cx';
 import { useAppByID } from '@utils/queries/useAppByID';
 import { useApps } from '@utils/queries/useApps';
@@ -98,6 +99,22 @@ export const Navbar: FC = () => {
                             </div>
                         </NavLink>
                     ))}
+
+                    {!app_id && userData?.admin === true && (
+                        <NavLink
+                            to={'/admin'}
+                            className={({ isActive }) =>
+                                cx(
+                                    'h-full block relative',
+                                    (isActive && 'navlink-active') || ''
+                                )
+                            }
+                        >
+                            <div className="flex items-center w-fit h-full border-r border-neutral-300 dark:border-neutral-700 pl-4 pr-4 cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-800">
+                                <div className="navtext">Admin</div>
+                            </div>
+                        </NavLink>
+                    )}
                     {/* <NavDropdown
                         list={[
                             { label: 'Dashboard', id: 0 },


### PR DESCRIPTION
The admin button in the navbar seems to have removed while restructuring for monorepo. This PR would add the button back with original functionality.